### PR TITLE
Bugfix/gaas maker merge outputs from datastore

### DIFF
--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -18,6 +18,8 @@ use IPC::Cmd qw[can_run run];
 use GAAS::GAAS;
 use Data::Dumper; # JN: debug
 
+my $DEBUG = 1; # JN: debug
+
 my $header     = get_gaas_header();
 my $output     = undef;
 my $in         = undef;
@@ -140,6 +142,11 @@ foreach my $makerDir (@inDir){
         mkdir $outfolder;
     }
 
+
+if ($DEBUG) {
+    # BEGIN DEBUG
+}
+else {
 # --------------- GATHERING gff and fasta ----------------------
     if ((grep -f, glob "$outfolder/*.fasta") or (grep -f, glob "$outfolder/*.gff")) {
         print "Output fasta/gff file already exists. We skip the gathering step.\n";
@@ -166,6 +173,7 @@ foreach my $makerDir (@inDir){
             }
         }
     }
+} # end DEBUG
 
     #-------------------------------------------------Save maker option files-------------------------------------------------
     print "Now save a copy of the Maker option files ...\n";

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -92,7 +92,9 @@ else {
     }
 }
 
-print Dumper(@inDir);warn "\n  inDir array (hit return to continue)\n" and getc();
+if ($DEBUG) {
+    print Dumper(@inDir);warn "\n  inDir array (hit return to continue)\n" and getc();
+}
 
 # CONSTANT
 my $maker_annotation_prefix = "maker_annotation";
@@ -180,9 +182,11 @@ else {
     opendir(CTLDIR, $ctlfolder) or die "couldn't open $cwdir: $!\n";
     my @ctl_files = grep { -f && /\.ctl$/ } readdir CTLDIR; # JN: All .ctl files
     closedir CTLDIR;
-    print Dumper(@ctl_files);warn "\n ctl files (hit return to continue)\n" and getc();
-    print Dumper($outfolder);warn "\n outfolder (hit return to continue)\n" and getc();
-    print Dumper($ctlfolder);warn "\n ctlfolder (hit return to continue)\n" and getc();
+    if ($DEBUG) {
+        print Dumper(@ctl_files);warn "\n ctl files (hit return to continue)\n" and getc();
+        print Dumper($outfolder);warn "\n outfolder (hit return to continue)\n" and getc();
+        print Dumper($ctlfolder);warn "\n ctlfolder (hit return to continue)\n" and getc();
+    }
 
     foreach my $file (@ctl_files) {
         if (-f "$outfolder/$file") {
@@ -214,6 +218,10 @@ else {
     #    }
     #}
 
+    if ($DEBUG) {
+        # Skip the next code blocks
+    }
+    else {
 
     ######################################################
     # Now manage to split file by kind of data           #
@@ -242,6 +250,7 @@ else {
         if ($full_path) {
             system "agat_sp_statistics.pl --gff $annotation -o $annotation_stat > $outfolder/maker_annotation_parsing.log";
         }
+    }
     }
     print "All done!\n";
 }

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -22,15 +22,15 @@ my $header     = get_gaas_header();
 my $output     = undef;
 my $in         = undef;
 my $help       = 0;
-my $ctl_folder = "."; # JN: Default is cwd for finding .ctl files
+my $cwdir      = getcwd;
+my $ctlfolder  = getcwd;
 my @inDir;
-my $cwdir = getcwd;
 
 GetOptions(
     "help|h"         => \$help,
     "i=s"            => \$in,
     "output|out|o=s" => \$output,
-    "ctlfolder|c=s"  => \$ctl_folder
+    "ctlfolder|c=s"  => \$ctlfolder
     )
     or pod2usage({
     -message => 'Failed to parse command line',
@@ -169,18 +169,18 @@ foreach my $makerDir (@inDir){
 
     #-------------------------------------------------Save maker option files-------------------------------------------------
     print "Now save a copy of the Maker option files ...\n";
-    my @ctl_files = grep { -f && /\.ctl$/ } readdir $ctl_folder; # JN: All .ctl files
+    my @ctl_files = grep { -f && /\.ctl$/ } readdir $ctlfolder; # JN: All .ctl files
     print Dumper(@ctl_files);warn "\n ctl files (hit return to continue)\n" and getc();
     print Dumper($outfolder);warn "\n outfolder (hit return to continue)\n" and getc();
-    print Dumper($ctl_folder);warn "\n ctl_folder (hit return to continue)\n" and getc();
+    print Dumper($ctlfolder);warn "\n ctlfolder (hit return to continue)\n" and getc();
 
     foreach my $file (@ctl_files) {
         if (-f "$outfolder/$file") {
             print "$file already exists in $outfolder. We will skip it.\n";
         }
         else {
-            print STDERR "JN: DEBUG Trying to copy $ctl_folder/$file ----> $outfolder/$file\n";
-            copy("$ctl_folder/$file", "$outfolder/$file")
+            print STDERR "JN: DEBUG Trying to copy $ctlfolder/$file ----> $outfolder/$file\n";
+            copy("$ctlfolder/$file", "$outfolder/$file")
                 or warn "Copy failed: $! $outfolder/$file\n";
         }
     }

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -49,26 +49,26 @@ my @inDir;
 my $dir = getcwd;
 
 if(! $in){
-	# Find the datastore index
-	my $maker_dir = undef;
+    # Find the datastore index
+    my $maker_dir = undef;
 
-	opendir(DIR, $dir) or die "couldn't open $dir: $!\n";
-	my @dirList = readdir DIR;
-	closedir DIR;
+    opendir(DIR, $dir) or die "couldn't open $dir: $!\n";
+    my @dirList = readdir DIR;
+    closedir DIR;
 
-	my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
+    my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
 
-	foreach my $makerDir (@matchedDir){
-		push(@inDir, $makerDir);
-	}
+    foreach my $makerDir (@matchedDir){
+        push(@inDir, $makerDir);
+    }
 }
 else{
-	if (! -d "$in") {
-		die "The outdirectory $in doesn't exist.\n";
-	}
-	else{
-		push(@inDir, $in);
-	}
+    if (! -d "$in") {
+        die "The outdirectory $in doesn't exist.\n";
+    }
+    else{
+        push(@inDir, $in);
+    }
 }
 
 # MESSAGES
@@ -76,7 +76,7 @@ my $nbDir=$#inDir+1;
 if ($nbDir == 0){die "There seems to be no maker output directory here, exiting...\n";}
 print "We found $nbDir maker output directorie(s):\n";
 foreach my $makerDir (@inDir){
-		print "\t+$makerDir\n";
+        print "\t+$makerDir\n";
 }
 
 #CONSTANT
@@ -91,115 +91,115 @@ my $maker_mix_prefix = "maker_mix";
 # Read the genome_datastore #
 #############################
 foreach my $makerDir (@inDir){
-	print "\nDealing with $makerDir:\n";
-	my %file_hds;
-	my $genomeName = $makerDir;
-	$genomeName =~ s/\.maker\.output.*//;
-	my $maker_dir_path = $dir . "/" . $makerDir."/";
-	my $datastore = $maker_dir_path.$genomeName."_datastore" ;
+    print "\nDealing with $makerDir:\n";
+    my %file_hds;
+    my $genomeName = $makerDir;
+    $genomeName =~ s/\.maker\.output.*//;
+    my $maker_dir_path = $dir . "/" . $makerDir."/";
+    my $datastore = $maker_dir_path.$genomeName."_datastore" ;
 
 # --------------- check presence datastore ----------------------
-	if (-d $datastore ) {
-        	print "Datastore folder found in $makerDir, merging annotations now...\n";
-	} else {
-	        die "Could not find datastore index ($datastore), exiting...\n";
-	}
+    if (-d $datastore ) {
+            print "Datastore folder found in $makerDir, merging annotations now...\n";
+    } else {
+            die "Could not find datastore index ($datastore), exiting...\n";
+    }
 # --------------- check output folder ----------------------
 
-	my $outfolder = undef;
-	if ($output){
-		if ($nbDir == 1){
-			$outfolder = $output;
-		}
-		else{
-			$outfolder = $output."_$genomeName";
-		}
-	}
-	else{ $outfolder = "maker_output_processed_$genomeName";}
-	if (-d "$outfolder") {
-		print "The output directory <$outfolder> already exists, let's see if something is missing inside.\n";
-	}
-	else{
-		print "Creating the $outfolder folder\n";
-		mkdir $outfolder;
-	}
+    my $outfolder = undef;
+    if ($output){
+        if ($nbDir == 1){
+            $outfolder = $output;
+        }
+        else{
+            $outfolder = $output."_$genomeName";
+        }
+    }
+    else{ $outfolder = "maker_output_processed_$genomeName";}
+    if (-d "$outfolder") {
+        print "The output directory <$outfolder> already exists, let's see if something is missing inside.\n";
+    }
+    else{
+        print "Creating the $outfolder folder\n";
+        mkdir $outfolder;
+    }
 
 # --------------- GATHERING gff and fasta ----------------------
-	if ( ( grep -f, glob "$outfolder/*.fasta") or ( grep -f, glob "$outfolder/*.gff") ){
-		print "Output fasta/gff file already exists. We skip the gathering step.\n";
-	}
-	else{
-		print "Now collecting gff and fasta files...\n";
-		collect_recursive(\%file_hds, $datastore, $outfolder, $genomeName);
+    if ( ( grep -f, glob "$outfolder/*.fasta") or ( grep -f, glob "$outfolder/*.gff") ){
+        print "Output fasta/gff file already exists. We skip the gathering step.\n";
+    }
+    else{
+        print "Now collecting gff and fasta files...\n";
+        collect_recursive(\%file_hds, $datastore, $outfolder, $genomeName);
 
-		#Close all file_handler opened that are not gff (gff files created by awk)
-		foreach my $key (keys %file_hds){
-			close $file_hds{$key};
-		}
-		#add ##gff-version 3 header to all gff files
-		opendir(DIR, $outfolder);
-		my @gff_files = grep(/\.gff$/,readdir(DIR));
-		closedir(DIR);
+        #Close all file_handler opened that are not gff (gff files created by awk)
+        foreach my $key (keys %file_hds){
+            close $file_hds{$key};
+        }
+        #add ##gff-version 3 header to all gff files
+        opendir(DIR, $outfolder);
+        my @gff_files = grep(/\.gff$/,readdir(DIR));
+        closedir(DIR);
 
-		foreach my $gff_file (@gff_files) {
-		    if($^O =~ "linux"){
-		   		system "sed -i '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file";
-		    }
-			else{
-		   		system "sed -i '' '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file"; # Mac syntax
-			}
-		}
-	}
+        foreach my $gff_file (@gff_files) {
+            if($^O =~ "linux"){
+                   system "sed -i '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file";
+            }
+            else{
+                   system "sed -i '' '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file"; # Mac syntax
+            }
+        }
+    }
 
-	#-------------------------------------------------Save maker option files-------------------------------------------------
-	print "Now save a copy of the Maker option files ...\n";
-	if (-f "$outfolder/maker_opts.ctl") {
-		print "A copy of the Maker files already exists in $outfolder/maker_opts.ctl.  We skip it.\n";
-	}
-	else{
-		if(! $in){
-			copy("maker_opts.ctl","$outfolder/maker_opts.ctl") or print "Copy failed: $! $outfolder/maker_opts.ctl\n";
-			copy("maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
-			copy("maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
-			copy("maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
-		}
-		else{
-			my ($name,$path,$suffix) = fileparse($in);
-			copy("$path/maker_opts.ctl","$outfolder/maker_opts.ctl") or print  "Copy failed: $! $outfolder/maker_opts.ctl\n";
-			copy("$path/maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
-			copy("$path/maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
-			copy("$path/maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
-		}
-	}
-
-
-	############################################
-	# Now manage to split file by kind of data # Split is done on the fly (no data saved in memory)
-	############################################
-	print "Now protecting the maker_annotation.gff annotation by making it readable only...\n";
-	#make the annotation safe
-	my $annotation="$outfolder/maker_annotation.gff";
-	if (-f $annotation) {
-		system "chmod 444 $annotation";
-	}
-	else{
-		print "ERROR: Do not find the $annotation file !\n";
-	}
+    #-------------------------------------------------Save maker option files-------------------------------------------------
+    print "Now save a copy of the Maker option files ...\n";
+    if (-f "$outfolder/maker_opts.ctl") {
+        print "A copy of the Maker files already exists in $outfolder/maker_opts.ctl.  We skip it.\n";
+    }
+    else{
+        if(! $in){
+            copy("maker_opts.ctl","$outfolder/maker_opts.ctl") or print "Copy failed: $! $outfolder/maker_opts.ctl\n";
+            copy("maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
+            copy("maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
+            copy("maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
+        }
+        else{
+            my ($name,$path,$suffix) = fileparse($in);
+            copy("$path/maker_opts.ctl","$outfolder/maker_opts.ctl") or print  "Copy failed: $! $outfolder/maker_opts.ctl\n";
+            copy("$path/maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
+            copy("$path/maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
+            copy("$path/maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
+        }
+    }
 
 
-	#do statistics
-	my $annotation_stat="$outfolder/maker_annotation_stat.txt";
-	if (-f $annotation_stat) {
-		print "$annotation_stat file already exsits...\n";
-	}
-	else{
-		print "Now performing the statistics of the annotation file $annotation...\n";
-		my $full_path = can_run('agat_sp_statistics.pl') or print "Cannot launch statistics. agat_sp_statistics.pl script not available\n";
-		if ($full_path) {
-		        system "agat_sp_statistics.pl --gff $annotation -o $annotation_stat > $outfolder/maker_annotation_parsing.log";
-		}
-	}
-	print "All done!\n";
+    ############################################
+    # Now manage to split file by kind of data # Split is done on the fly (no data saved in memory)
+    ############################################
+    print "Now protecting the maker_annotation.gff annotation by making it readable only...\n";
+    #make the annotation safe
+    my $annotation="$outfolder/maker_annotation.gff";
+    if (-f $annotation) {
+        system "chmod 444 $annotation";
+    }
+    else{
+        print "ERROR: Do not find the $annotation file !\n";
+    }
+
+
+    #do statistics
+    my $annotation_stat="$outfolder/maker_annotation_stat.txt";
+    if (-f $annotation_stat) {
+        print "$annotation_stat file already exsits...\n";
+    }
+    else{
+        print "Now performing the statistics of the annotation file $annotation...\n";
+        my $full_path = can_run('agat_sp_statistics.pl') or print "Cannot launch statistics. agat_sp_statistics.pl script not available\n";
+        if ($full_path) {
+                system "agat_sp_statistics.pl --gff $annotation -o $annotation_stat > $outfolder/maker_annotation_parsing.log";
+        }
+    }
+    print "All done!\n";
 }
 
 #######################################################################################################################
@@ -217,66 +217,66 @@ foreach my $makerDir (@inDir){
 sub collect_recursive {
     my ($file_hds, $full_path, $out, $genomeName) = @_;
 
-	my ($name,$path,$suffix) = fileparse($full_path,qr/\.[^.]*/);
+    my ($name,$path,$suffix) = fileparse($full_path,qr/\.[^.]*/);
 
     if( ! -d $full_path ){
 
-    	###################
-    	# deal with fasta #
-    	if($suffix eq ".fasta"){
-    		my $key = undef;
-    		my $type = undef;
-    		if($name =~ /([^\.]+)\.transcripts/){
-    			$key = $1;
-    			$type = "transcripts";
-    		}
-    		if($name =~ /([^\.]+)\.proteins/){
-    			$key = $1;
-    			$type = "proteins";
-    		}
-    		if($name =~ /([^\.]+)\.noncoding/){
-    			$key = $1;
-    			$type = "noncoding";
-    		}
-    		if($key){
-    			my $prot_out_file_name=undef;
-    			if ($key eq 'maker'){ # protein or transcript correspinding to the maker annotation
-					$prot_out_file_name = "$maker_annotation_prefix.$type.fasta";
-    			}
-    			else{
-    				my $source = "maker.$key";
-    				$prot_out_file_name = "$genomeName.all.$source.$type.fasta";
-    			}
+        ###################
+        # deal with fasta #
+        if($suffix eq ".fasta"){
+            my $key = undef;
+            my $type = undef;
+            if($name =~ /([^\.]+)\.transcripts/){
+                $key = $1;
+                $type = "transcripts";
+            }
+            if($name =~ /([^\.]+)\.proteins/){
+                $key = $1;
+                $type = "proteins";
+            }
+            if($name =~ /([^\.]+)\.noncoding/){
+                $key = $1;
+                $type = "noncoding";
+            }
+            if($key){
+                my $prot_out_file_name=undef;
+                if ($key eq 'maker'){ # protein or transcript correspinding to the maker annotation
+                    $prot_out_file_name = "$maker_annotation_prefix.$type.fasta";
+                }
+                else{
+                    my $source = "maker.$key";
+                    $prot_out_file_name = "$genomeName.all.$source.$type.fasta";
+                }
 
-				my $protein_out_fh=undef;
-				if( _exists_keys ($file_hds,($prot_out_file_name)) ){
-					$protein_out_fh = $file_hds->{$prot_out_file_name};
-				}
-				else{
-					open($protein_out_fh, '>', "$out/$prot_out_file_name") or die "Could not open file '$out/$prot_out_file_name' $!";
-					$file_hds->{$prot_out_file_name}=$protein_out_fh;
-				}
+                my $protein_out_fh=undef;
+                if( _exists_keys ($file_hds,($prot_out_file_name)) ){
+                    $protein_out_fh = $file_hds->{$prot_out_file_name};
+                }
+                else{
+                    open($protein_out_fh, '>', "$out/$prot_out_file_name") or die "Could not open file '$out/$prot_out_file_name' $!";
+                    $file_hds->{$prot_out_file_name}=$protein_out_fh;
+                }
 
-	    		#print
-	    		open(my $fh, '<:encoding(UTF-8)', $full_path) or die "Could not open file '$full_path' $!";
-					while (<$fh>) {
-						print $protein_out_fh $_;
-					}
-				close $fh;
-    		}
-    	}
+                #print
+                open(my $fh, '<:encoding(UTF-8)', $full_path) or die "Could not open file '$full_path' $!";
+                    while (<$fh>) {
+                        print $protein_out_fh $_;
+                    }
+                close $fh;
+            }
+        }
 
-    	################
- 		#deal with gff #
-    	if($suffix eq ".gff"){
-    		system "awk -F '	' 'NF==9 {print \$0 >> \"$out/$maker_mix_prefix.gff\"}' $full_path";
-				system "awk '{if(\$2 ~ /[a-zA-Z]+/) if(\$2==\"maker\") { print \$0 >> \"$out/$maker_annotation_prefix.gff\" } else { OFS=\"\\t\"; gsub(/:/, \"_\" ,\$2); print \$0 >> \"$out/\"\$2\".gff\" } }' $full_path";
-    	}
+        ################
+         #deal with gff #
+        if($suffix eq ".gff"){
+            system "awk -F '    ' 'NF==9 {print \$0 >> \"$out/$maker_mix_prefix.gff\"}' $full_path";
+                system "awk '{if(\$2 ~ /[a-zA-Z]+/) if(\$2==\"maker\") { print \$0 >> \"$out/$maker_annotation_prefix.gff\" } else { OFS=\"\\t\"; gsub(/:/, \"_\" ,\$2); print \$0 >> \"$out/\"\$2\".gff\" } }' $full_path";
+        }
 
-    	return;
+        return;
     }
     if($name =~ /^theVoid/){ # In the void there is sub results already stored in the up folder. No need to go such deep otherwise we will have duplicates.
-    	return;
+        return;
     }
     opendir my $dh, $full_path or die;
     while (my $sub = readdir $dh) {

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -16,12 +16,13 @@ use IO::File;
 use File::Basename;
 use IPC::Cmd qw[can_run run];
 use GAAS::GAAS;
+use Data::Dumper; # JN: debug
 
 my $header     = get_gaas_header();
 my $output     = undef;
 my $in         = undef;
 my $help       = 0;
-my $ctl_folder = "."; # Default is cwd for finding .ctl files
+my $ctl_folder = "."; # JN: Default is cwd for finding .ctl files
 my @inDir;
 my $cwdir = getcwd;
 
@@ -73,6 +74,9 @@ else {
         }
     }
 }
+
+print Dumper(@inDir);warn "\n  inDir array (hit return to continue)\n" and getc();
+
 
 # MESSAGES
 my $nbDir = scalar @inDir;

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -75,9 +75,6 @@ else {
     }
 }
 
-print Dumper(@inDir);warn "\n  inDir array (hit return to continue)\n" and getc();
-
-
 # MESSAGES
 my $nbDir = scalar @inDir;
 if ($nbDir == 0) {
@@ -92,6 +89,8 @@ else {
         print "\t+$makerDir\n";
     }
 }
+
+print Dumper(@inDir);warn "\n  inDir array (hit return to continue)\n" and getc();
 
 # CONSTANT
 my $maker_annotation_prefix = "maker_annotation";

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -72,16 +72,21 @@ else {
 }
 
 # MESSAGES
-my $nbDir = $#inDir+1;
+my $nbDir = scalar @inDir;
 if ($nbDir == 0) {
     die "There seems to be no maker output directory here, exiting...\n";
 }
-print "We found $nbDir maker output directorie(s):\n";
-foreach my $makerDir (@inDir) {
-    print "\t+$makerDir\n";
+elsif ($nbDir == 1) {
+    print "We found maker output directory: $inDir[0]\n";
+}
+else {
+    print "We found $nbDir maker output directories:\n";
+    foreach my $makerDir (@inDir) {
+        print "\t+$makerDir\n";
+    }
 }
 
-#CONSTANT
+# CONSTANT
 my $maker_annotation_prefix = "maker_annotation";
 my $maker_mix_prefix = "maker_mix";
 

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -71,7 +71,7 @@ else {
 
     foreach my $dir (@dirList) {
         next if ($dir =~ /.*processed.*/); # JN: Assuming processed folders have this string
-        if ($_ =~ /^.*\.maker\.output/) {  # JN: Allowing folders not ending in maker.output
+        if ($dir =~ /^.*\.maker\.output/) {  # JN: Allowing folders not ending in maker.output
             push(@inDir, $dir);
         }
     }

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -22,6 +22,8 @@ my $output     = undef;
 my $in         = undef;
 my $help       = 0;
 my $ctl_folder = "."; # Default is cwd for finding .ctl files
+my @inDir;
+my $cwdir = getcwd;
 
 GetOptions(
     "help|h"         => \$help,
@@ -50,14 +52,20 @@ if ($help) {
 #######################
 
 # MANAGE IN
-my @inDir;
-my $dir = getcwd;
+if ($in) {
+    if (! -d "$in") {
+        die "The input directory $in doesn't exist.\n";
+    }
+    else {
+        push(@inDir, $in);
+    }
+}
+else {
 
-if (! $in) {
     # Find the datastore index
     my $maker_dir = undef;
 
-    opendir(DIR, $dir) or die "couldn't open $dir: $!\n";
+    opendir(DIR, $cwdir) or die "couldn't open $cwdir: $!\n";
     my @dirList = readdir DIR;
     closedir DIR;
 
@@ -67,14 +75,36 @@ if (! $in) {
         push(@inDir, $makerDir);
     }
 }
-else {
-    if (! -d "$in") {
-        die "The outdirectory $in doesn't exist.\n";
-    }
-    else {
-        push(@inDir, $in);
-    }
-}
+
+#if (! $in) {
+#    # Find the datastore index
+#    my $maker_dir = undef;
+#
+#    opendir(DIR, $dir) or die "couldn't open $dir: $!\n";
+#    my @dirList = readdir DIR;
+#    closedir DIR;
+#
+#    my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
+#
+#    foreach my $makerDir (@matchedDir) {
+#        push(@inDir, $makerDir);
+#    }
+#}
+#else {
+#    if (! -d "$in") {
+#        die "The outdirectory $in doesn't exist.\n";
+#    }
+#    else {
+#        push(@inDir, $in);
+#    }
+#}
+
+
+
+
+
+
+
 
 # MESSAGES
 my $nbDir = scalar @inDir;
@@ -107,7 +137,7 @@ foreach my $makerDir (@inDir){
     my %file_hds;
     my $genomeName = $makerDir;
     $genomeName =~ s/\.maker\.output.*//;
-    my $maker_dir_path = $dir . "/" . $makerDir . "/";
+    my $maker_dir_path = $cwdir . "/" . $makerDir . "/";
     my $datastore = $maker_dir_path . $genomeName . "_datastore" ;
 
 # --------------- check presence datastore ----------------------

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -169,7 +169,7 @@ foreach my $makerDir (@inDir){
 
     #-------------------------------------------------Save maker option files-------------------------------------------------
     print "Now save a copy of the Maker option files ...\n";
-    my @ctl_files = grep { -f && /\.clt$/ } readdir $ctl_folder;
+    my @ctl_files = grep { -f && /\.ctl$/ } readdir $ctl_folder; # JN: All .ctl files
     foreach my $file (@ctl_files) {
         if (-f "$outfolder/$file") {
             print "$file already exists in $outfolder. We will skip it.\n";

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -28,43 +28,22 @@ GetOptions(
     "i=s"            => \$in,
     "output|out|o=s" => \$output,
     "ctlfolder|c=s"  => \$ctl_folder
-  )
-  or pod2usage(
-    {
-        -message => 'Failed to parse command line',
-        -verbose => 1,
-        -exitval => 1
+    )
+    or pod2usage({
+    -message => 'Failed to parse command line',
+    -verbose => 1,
+    -exitval => 1
     }
-  );
+);
 
 # Print Help and exit
 if ($help) {
-    pod2usage(
-        {
-            -verbose => 99,
-            -exitval => 0,
-            -message => "$header\n"
-        }
-    );
+    pod2usage({
+        -verbose => 99,
+        -exitval => 0,
+        -message => "$header\n"
+    });
 }
-
-# if ( !GetOptions(
-#     "help|h" => \$help,
-#     "i=s" => \$in,
-#     "output|out|o=s" => \$output))
-# 
-# {
-#     pod2usage( { -message => 'Failed to parse command line',
-#                  -verbose => 1,
-#                  -exitval => 1 } );
-# }
-# 
-# # Print Help and exit
-# if ($help) {
-#     pod2usage( { -verbose => 99,
-#                  -exitval => 0,
-#                  -message => "$header\n" } );
-# }
 
 #######################
 ### MANAGE OPTIONS ####

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -170,35 +170,39 @@ foreach my $makerDir (@inDir){
     #-------------------------------------------------Save maker option files-------------------------------------------------
     print "Now save a copy of the Maker option files ...\n";
     my @ctl_files = grep { -f && /\.ctl$/ } readdir $ctl_folder; # JN: All .ctl files
+    print Dumper(@ctl_files);warn "\n ctl files (hit return to continue)\n" and getc();
+    print Dumper($outfolder);warn "\n outfolder (hit return to continue)\n" and getc();
+    print Dumper($ctl_folder);warn "\n ctl_folder (hit return to continue)\n" and getc();
+
     foreach my $file (@ctl_files) {
         if (-f "$outfolder/$file") {
             print "$file already exists in $outfolder. We will skip it.\n";
         }
         else {
+            print STDERR "JN: DEBUG Trying to copy $ctl_folder/$file ----> $outfolder/$file\n";
             copy("$ctl_folder/$file", "$outfolder/$file")
                 or warn "Copy failed: $! $outfolder/$file\n";
         }
     }
 
-
-    if (-f "$outfolder/maker_opts.ctl") {
-        print "A copy of the Maker files already exists in $outfolder/maker_opts.ctl.  We skip it.\n";
-    }
-    else {
-        if (! $in) {
-            copy("maker_opts.ctl","$outfolder/maker_opts.ctl") or print "Copy failed: $! $outfolder/maker_opts.ctl\n";
-            copy("maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
-            copy("maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
-            copy("maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
-        }
-        else {
-            my ($name,$path,$suffix) = fileparse($in);
-            copy("$path/maker_opts.ctl","$outfolder/maker_opts.ctl") or print  "Copy failed: $! $outfolder/maker_opts.ctl\n";
-            copy("$path/maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
-            copy("$path/maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
-            copy("$path/maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
-        }
-    }
+    #if (-f "$outfolder/maker_opts.ctl") {
+    #    print "A copy of the Maker files already exists in $outfolder/maker_opts.ctl.  We skip it.\n";
+    #}
+    #else {
+    #    if (! $in) {
+    #        copy("maker_opts.ctl","$outfolder/maker_opts.ctl") or print "Copy failed: $! $outfolder/maker_opts.ctl\n";
+    #        copy("maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
+    #        copy("maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
+    #        copy("maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
+    #    }
+    #    else {
+    #        my ($name,$path,$suffix) = fileparse($in);
+    #        copy("$path/maker_opts.ctl","$outfolder/maker_opts.ctl") or print  "Copy failed: $! $outfolder/maker_opts.ctl\n";
+    #        copy("$path/maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
+    #        copy("$path/maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
+    #        copy("$path/maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
+    #    }
+    #}
 
 
     ######################################################

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -48,7 +48,7 @@ if ($help) {
 my @inDir;
 my $dir = getcwd;
 
-if(! $in){
+if (! $in) {
     # Find the datastore index
     my $maker_dir = undef;
 
@@ -58,25 +58,27 @@ if(! $in){
 
     my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
 
-    foreach my $makerDir (@matchedDir){
+    foreach my $makerDir (@matchedDir) {
         push(@inDir, $makerDir);
     }
 }
-else{
+else {
     if (! -d "$in") {
         die "The outdirectory $in doesn't exist.\n";
     }
-    else{
+    else {
         push(@inDir, $in);
     }
 }
 
 # MESSAGES
-my $nbDir=$#inDir+1;
-if ($nbDir == 0){die "There seems to be no maker output directory here, exiting...\n";}
+my $nbDir = $#inDir+1;
+if ($nbDir == 0) {
+    die "There seems to be no maker output directory here, exiting...\n";
+}
 print "We found $nbDir maker output directorie(s):\n";
-foreach my $makerDir (@inDir){
-        print "\t+$makerDir\n";
+foreach my $makerDir (@inDir) {
+    print "\t+$makerDir\n";
 }
 
 #CONSTANT
@@ -95,58 +97,61 @@ foreach my $makerDir (@inDir){
     my %file_hds;
     my $genomeName = $makerDir;
     $genomeName =~ s/\.maker\.output.*//;
-    my $maker_dir_path = $dir . "/" . $makerDir."/";
-    my $datastore = $maker_dir_path.$genomeName."_datastore" ;
+    my $maker_dir_path = $dir . "/" . $makerDir . "/";
+    my $datastore = $maker_dir_path . $genomeName . "_datastore" ;
 
 # --------------- check presence datastore ----------------------
-    if (-d $datastore ) {
-            print "Datastore folder found in $makerDir, merging annotations now...\n";
-    } else {
-            die "Could not find datastore index ($datastore), exiting...\n";
+    if (-d $datastore) {
+        print "Datastore folder found in $makerDir, merging annotations now...\n";
+    }
+    else {
+        die "Could not find datastore index ($datastore), exiting...\n";
     }
 # --------------- check output folder ----------------------
 
     my $outfolder = undef;
-    if ($output){
-        if ($nbDir == 1){
+    if ($output) {
+        if ($nbDir == 1) {
             $outfolder = $output;
         }
-        else{
-            $outfolder = $output."_$genomeName";
+        else {
+            $outfolder = $output . "_$genomeName";
         }
     }
-    else{ $outfolder = "maker_output_processed_$genomeName";}
+    else {
+        $outfolder = "maker_output_processed_$genomeName";
+    }
     if (-d "$outfolder") {
         print "The output directory <$outfolder> already exists, let's see if something is missing inside.\n";
     }
-    else{
+    else {
         print "Creating the $outfolder folder\n";
         mkdir $outfolder;
     }
 
 # --------------- GATHERING gff and fasta ----------------------
-    if ( ( grep -f, glob "$outfolder/*.fasta") or ( grep -f, glob "$outfolder/*.gff") ){
+    if ((grep -f, glob "$outfolder/*.fasta") or (grep -f, glob "$outfolder/*.gff")) {
         print "Output fasta/gff file already exists. We skip the gathering step.\n";
     }
-    else{
+    else {
         print "Now collecting gff and fasta files...\n";
         collect_recursive(\%file_hds, $datastore, $outfolder, $genomeName);
 
-        #Close all file_handler opened that are not gff (gff files created by awk)
-        foreach my $key (keys %file_hds){
+        # Close all file_handler opened that are not gff (gff files created by awk)
+        foreach my $key (keys %file_hds) {
             close $file_hds{$key};
         }
-        #add ##gff-version 3 header to all gff files
+        # Add ##gff-version 3 header to all gff files
         opendir(DIR, $outfolder);
-        my @gff_files = grep(/\.gff$/,readdir(DIR));
+        my @gff_files = grep(/\.gff$/, readdir(DIR));
         closedir(DIR);
 
         foreach my $gff_file (@gff_files) {
-            if($^O =~ "linux"){
-                   system "sed -i '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file";
+            if ($^O =~ "linux") {
+                system "sed -i '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file";
             }
-            else{
-                   system "sed -i '' '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file"; # Mac syntax
+            else {
+                system "sed -i '' '1s/^/##gff-version 3\\\n/' $outfolder/$gff_file"; # Mac syntax
             }
         }
     }
@@ -156,14 +161,14 @@ foreach my $makerDir (@inDir){
     if (-f "$outfolder/maker_opts.ctl") {
         print "A copy of the Maker files already exists in $outfolder/maker_opts.ctl.  We skip it.\n";
     }
-    else{
-        if(! $in){
+    else {
+        if (! $in) {
             copy("maker_opts.ctl","$outfolder/maker_opts.ctl") or print "Copy failed: $! $outfolder/maker_opts.ctl\n";
             copy("maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
             copy("maker_evm.ctl","$outfolder/maker_evm.ctl") or print "Copy failed: $! $outfolder/maker_evm.ctl\n";
             copy("maker_bopts.ctl","$outfolder/maker_bopts.ctl") or print "Copy failed: $! $outfolder/maker_bopts.ctl\n";
         }
-        else{
+        else {
             my ($name,$path,$suffix) = fileparse($in);
             copy("$path/maker_opts.ctl","$outfolder/maker_opts.ctl") or print  "Copy failed: $! $outfolder/maker_opts.ctl\n";
             copy("$path/maker_exe.ctl","$outfolder/maker_exe.ctl") or print "Copy failed: $! $outfolder/maker_exe.ctl\n";
@@ -182,7 +187,7 @@ foreach my $makerDir (@inDir){
     if (-f $annotation) {
         system "chmod 444 $annotation";
     }
-    else{
+    else {
         print "ERROR: Do not find the $annotation file !\n";
     }
 
@@ -192,11 +197,11 @@ foreach my $makerDir (@inDir){
     if (-f $annotation_stat) {
         print "$annotation_stat file already exsits...\n";
     }
-    else{
+    else {
         print "Now performing the statistics of the annotation file $annotation...\n";
         my $full_path = can_run('agat_sp_statistics.pl') or print "Cannot launch statistics. agat_sp_statistics.pl script not available\n";
         if ($full_path) {
-                system "agat_sp_statistics.pl --gff $annotation -o $annotation_stat > $outfolder/maker_annotation_parsing.log";
+            system "agat_sp_statistics.pl --gff $annotation -o $annotation_stat > $outfolder/maker_annotation_parsing.log";
         }
     }
     print "All done!\n";
@@ -217,74 +222,76 @@ foreach my $makerDir (@inDir){
 sub collect_recursive {
     my ($file_hds, $full_path, $out, $genomeName) = @_;
 
-    my ($name,$path,$suffix) = fileparse($full_path,qr/\.[^.]*/);
+    my ($name, $path, $suffix) = fileparse($full_path, qr/\.[^.]*/);
 
-    if( ! -d $full_path ){
+    if (! -d $full_path) {
 
         ###################
         # deal with fasta #
-        if($suffix eq ".fasta"){
+        if ($suffix eq ".fasta") {
             my $key = undef;
             my $type = undef;
-            if($name =~ /([^\.]+)\.transcripts/){
+            if ($name =~ /([^\.]+)\.transcripts/) {
                 $key = $1;
                 $type = "transcripts";
             }
-            if($name =~ /([^\.]+)\.proteins/){
+            if ($name =~ /([^\.]+)\.proteins/) {
                 $key = $1;
                 $type = "proteins";
             }
-            if($name =~ /([^\.]+)\.noncoding/){
+            if ($name =~ /([^\.]+)\.noncoding/) {
                 $key = $1;
                 $type = "noncoding";
             }
-            if($key){
-                my $prot_out_file_name=undef;
-                if ($key eq 'maker'){ # protein or transcript correspinding to the maker annotation
+            if ($key) {
+                my $prot_out_file_name = undef;
+                if ($key eq 'maker') { # protein or transcript correspinding to the maker annotation
                     $prot_out_file_name = "$maker_annotation_prefix.$type.fasta";
                 }
-                else{
+                else {
                     my $source = "maker.$key";
                     $prot_out_file_name = "$genomeName.all.$source.$type.fasta";
                 }
 
-                my $protein_out_fh=undef;
-                if( _exists_keys ($file_hds,($prot_out_file_name)) ){
+                my $protein_out_fh = undef;
+                if (_exists_keys ($file_hds,($prot_out_file_name))) {
                     $protein_out_fh = $file_hds->{$prot_out_file_name};
                 }
-                else{
+                else {
                     open($protein_out_fh, '>', "$out/$prot_out_file_name") or die "Could not open file '$out/$prot_out_file_name' $!";
-                    $file_hds->{$prot_out_file_name}=$protein_out_fh;
+                    $file_hds->{$prot_out_file_name} = $protein_out_fh;
                 }
 
-                #print
+                # Print
                 open(my $fh, '<:encoding(UTF-8)', $full_path) or die "Could not open file '$full_path' $!";
-                    while (<$fh>) {
-                        print $protein_out_fh $_;
-                    }
+                while (<$fh>) {
+                    print $protein_out_fh $_;
+                }
                 close $fh;
             }
         }
 
-        ################
-         #deal with gff #
-        if($suffix eq ".gff"){
+        #################
+        # Deal with gff #
+        if ($suffix eq ".gff") {
             system "awk -F '    ' 'NF==9 {print \$0 >> \"$out/$maker_mix_prefix.gff\"}' $full_path";
-                system "awk '{if(\$2 ~ /[a-zA-Z]+/) if(\$2==\"maker\") { print \$0 >> \"$out/$maker_annotation_prefix.gff\" } else { OFS=\"\\t\"; gsub(/:/, \"_\" ,\$2); print \$0 >> \"$out/\"\$2\".gff\" } }' $full_path";
+            system "awk '{if(\$2 ~ /[a-zA-Z]+/) if(\$2==\"maker\") { print \$0 >> \"$out/$maker_annotation_prefix.gff\" } else { OFS=\"\\t\"; gsub(/:/, \"_\" ,\$2); print \$0 >> \"$out/\"\$2\".gff\" } }' $full_path";
         }
 
         return;
     }
-    if($name =~ /^theVoid/){ # In the void there is sub results already stored in the up folder. No need to go such deep otherwise we will have duplicates.
+
+    if ($name =~ /^theVoid/) { # In the void there is sub results already stored in the up folder. No need to go such deep otherwise we will have duplicates.
         return;
     }
+
     opendir my $dh, $full_path or die;
     while (my $sub = readdir $dh) {
         next if $sub eq '.' or $sub eq '..';
-
         collect_recursive($file_hds, "$full_path/$sub", $out, $genomeName);
     }
     close $dh;
+
     return;
 }
 
@@ -297,6 +304,7 @@ sub _exists_keys {
         }
         return 1;
     }
+
     return '';
 }
 

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -177,7 +177,9 @@ else {
 
     #-------------------------------------------------Save maker option files-------------------------------------------------
     print "Now save a copy of the Maker option files ...\n";
-    my @ctl_files = grep { -f && /\.ctl$/ } readdir $ctlfolder; # JN: All .ctl files
+    opendir(CTLDIR, $ctlfolder) or die "couldn't open $cwdir: $!\n";
+    my @ctl_files = grep { -f && /\.ctl$/ } readdir CTLDIR; # JN: All .ctl files
+    closedir CTLDIR;
     print Dumper(@ctl_files);warn "\n ctl files (hit return to continue)\n" and getc();
     print Dumper($outfolder);warn "\n outfolder (hit return to continue)\n" and getc();
     print Dumper($ctlfolder);warn "\n ctlfolder (hit return to continue)\n" and getc();

--- a/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
+++ b/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl
@@ -61,50 +61,18 @@ if ($in) {
     }
 }
 else {
-
     # Find the datastore index
-    my $maker_dir = undef;
-
     opendir(DIR, $cwdir) or die "couldn't open $cwdir: $!\n";
     my @dirList = readdir DIR;
     closedir DIR;
 
-    my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
-
-    foreach my $makerDir (@matchedDir) {
-        push(@inDir, $makerDir);
+    foreach my $dir (@dirList) {
+        next if ($dir =~ /.*processed.*/); # JN: Assuming processed folders have this string
+        if ($_ =~ /^.*\.maker\.output/) {  # JN: Allowing folders not ending in maker.output
+            push(@inDir, $dir);
+        }
     }
 }
-
-#if (! $in) {
-#    # Find the datastore index
-#    my $maker_dir = undef;
-#
-#    opendir(DIR, $dir) or die "couldn't open $dir: $!\n";
-#    my @dirList = readdir DIR;
-#    closedir DIR;
-#
-#    my (@matchedDir) = grep $_ =~ /^.*\.maker\.output$/ , @dirList ;
-#
-#    foreach my $makerDir (@matchedDir) {
-#        push(@inDir, $makerDir);
-#    }
-#}
-#else {
-#    if (! -d "$in") {
-#        die "The outdirectory $in doesn't exist.\n";
-#    }
-#    else {
-#        push(@inDir, $in);
-#    }
-#}
-
-
-
-
-
-
-
 
 # MESSAGES
 my $nbDir = scalar @inDir;


### PR DESCRIPTION
The following warning messages where observed:

    $ ~/git/NBIS/GAAS/annotation/tools/maker/gaas_maker_merge_outputs_from_datastore.pl \
       -i genome.maker.output_mixabinitio_abinitio_pacbio/ \
       -o genome.maker.output_mixabinitio_abinitio_pacbio_output_processed

    [...]
    Now save a copy of the Maker option files ...
    Copy failed: No such file or directory genome.maker.output_mixabinitio_abinitio_pacbio_output_processed/maker_opts.ctl
    Copy failed: No such file or directory genome.maker.output_mixabinitio_abinitio_pacbio_output_processed/maker_exe.ctl
    Copy failed: No such file or directory genome.maker.output_mixabinitio_abinitio_pacbio_output_processed/maker_evm.ctl
    Copy failed: No such file or directory genome.maker.output_mixabinitio_abinitio_pacbio_output_processed/maker_bopts.ctl

    Now protecting the maker_annotation.gff annotation by making it readable only...

    Now performing the statistics of the annotation file genome.maker.output_mixabinitio_abinitio_pacbio_output_processed/maker_ann
    otation.gff...
    WARNING get_longest_cds_level2: NO exon or cds to select the longest l2 for evm-000115f-processed-gene-1.0 l1 ! We will take on
    e randomly ! @


There are possibly two kinds of errors observed here. First is the failure of copying control files.

The second is the warning from get_longest_cds_level2. This have not yet been addressed.

One issue related to the error with paths and folders is that the script
searches for output folders from Maker ending in `maker.output` (line #59), but the case I
was given have folders ending in something else.

## Suggested changes

1. Change the regex to allow `maker.output` in the folder name (see also nr 3. below)

2. Add another option, `-c` or `--ctlfolder`, where the folder (or path) to the
   location of the Maker control files are located.  The default value is the
   current working directory -- just as the current behaviour -- so no need to
   change a workflow.  The logic here is that the current working directory
   may have several Maker output folders, and the same control files may, or
   may not, be applicable to all of them (an assumption from my side). A user
   may now, with the extra option `-c`, specify exactly where the control files
   are located, and to which Maker input and output folders they should be
   associated with (using the `-i`  and `-o` options).

3. The routine for searching for Maker output files is now changed, where we
   now search for any folder with the string `maker.output`, but excluding
   those with the string `processed`. One complication is that the script does
   not halt if existing output folders are present (in case it would have been
   simpler to handle), but does continue. And since there is an `--output` option
   where the user can specify any name, the filtering on `processed` may not be
   sufficient.  One may need to use other indicators to test if an older output
   folder is present, perhaps look for specific output files?

4. Multiple changes where made regarding code formatting. I tried to be consistent.

