### PR TITLE
Gaas create annotation project

### DIFF
--- a/bin/gaas_create_annotation_project.pl
+++ b/bin/gaas_create_annotation_project.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # file: gaas_create_annotation_project.pl
-# Last modified: ons feb 02, 2022  02:24
+# Last modified: tor feb 03, 2022  11:34
 # Sign: Johan Nylander
 
 use strict;
@@ -20,7 +20,8 @@ my @folders = (
     "abinitio",
     "customer_data",
     "genome",
-    "maker",
+    "maker/maker_evidence",
+    "maker/maker_abinitio",
     "organelles",
     "repeats",
     "rfam",
@@ -67,7 +68,6 @@ if ( -e $full_path) {
 else {
     for my $folder (@folders) {
         my $f = $full_path . "/" . $folder;
-        #system("mkdir -p $f");
         make_path($f)
     }
 }

--- a/bin/gaas_create_annotation_project.pl
+++ b/bin/gaas_create_annotation_project.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # file: gaas_create_annotation_project.pl
-# Last modified: fre feb 11, 2022  03:29
+# Last modified: fre feb 11, 2022  03:32
 # Sign: Johan Nylander
 
 use strict;
@@ -19,7 +19,7 @@ my $full_path = q{};
 my @folders = (
     "abinitio",
     "customer_data",
-    "genome",
+    "assembly",
     "maker/maker_evidence",
     "maker/maker_abinitio",
     "organelles",
@@ -169,10 +169,11 @@ Without any arguments, this is the expected output
 
     Genus_species-annotation_version-NBIS_ID/
         |── abinitio/
+        |── assembly/
         |── customer_data/
-        |── genome/
         |── maker/
         |── organelles/
+        |── public_data/
         |── repeats/
         |── rfam/
         |── RNAseq/

--- a/bin/gaas_create_annotation_project.pl
+++ b/bin/gaas_create_annotation_project.pl
@@ -1,113 +1,193 @@
 #!/usr/bin/env perl
 
-#
-#This script creates directories needed for a new project:
-#
-#NBIS 2018
-#Nima Rafati
+# file: gaas_create_annotation_project.pl
+# Last modified: ons feb 02, 2022  02:20
+# Sign: Johan Nylander
+
 use strict;
+use warnings;
 use Getopt::Long;
 use Pod::Usage;
-use File::Path;
+use File::Path qw(make_path);
 
+## Globals
+my $annotation_root = "/home/nylander/tmp/gaas"; #"/projects/annotation"
+my $default_name = "Genus_species-annotation_version-NBIS_ID";
+my $logname = $ENV{LOGNAME};
+my $time_stamp = localtime();
+my $full_path = q{};
+my @folders = (
+    "abinitio",
+    "customer_data",
+    "genome",
+    "maker",
+    "organelles",
+    "repeats",
+    "rfam",
+    "RNAseq");
 
-my $logname = $ENV{ LOGNAME };
-my $help;
-my $fasta = undef;
+## Options
+my $name = undef;
+my $assembly_version = undef;
+my $id = undef;
+my $path = undef;
 my $version = undef;
-my $species = undef;
-my $annotation_root = "/projects/annotation";
-#my $annotation_root = "~/test_annotation/";
-my $usage = qq{
-perl $0
-	Getting help:
-	[-help]
-	Input:
-	[-s species_name]
-	[-g genome.fa]
-	[-v assembly version]
-	[-path path to project directory (default: /projects/annotation)]
-};
+my $help = undef;
+my $man = undef;
 
-GetOptions( 
-"help" => \$help,
-"s=s" => \$species,
-"g=s" => \$fasta,
-"v=i" => \$version,
-"path=s" => \$annotation_root);
+GetOptions(
+    "s|name=s" => \$name,
+    "assembly-version=s" => \$assembly_version,
+    "i|id=s" => \$id,
+    "path=s" => \$path,
+    "version" => \$version,
+    "help" => \$help,
+    "man" => \$man,
+);
 
-# Print Help and exit
-if ($help) {
-	print $usage;
-	exit(0);
+pod2usage(1) if ($help);
+pod2usage(-exitval => 0, -verbose => 99, -sections => 'VERSION') if ($version);
+pod2usage(-exitval => 0, -verbose => 2) if ($man);
+
+## Check if path: then use this string, else use name
+if ($path) {
+    $full_path = $path;
 }
-#check all parameters
-if ( !( defined($fasta))){
-	 pod2usage( { -message => "\nA fasta file for genome assembly must be provided (-g)\n$usage",
--verbose => 0,
--exitval => 2 } );
+elsif ($name) {
+    $full_path = $annotation_root . "/" . $name;
 }
-if ( !( defined($species))){
-	 pod2usage( { -message => "\nA species name must be provided (-s)\n$usage",
--verbose => 0,
--exitval => 2 } );
-}
-if ( !( defined($version))){
-	 pod2usage( { -message => "\nVersion of the genome assembly must be provided (-v)\n$usage",
--verbose => 0,
--exitval => 2 } );
+else {
+    $full_path = $annotation_root . "/" . $default_name;
 }
 
-my $project_path = "$annotation_root/$species/";
-print "This project \" $species v.$version\" was created by \$logname = $logname on ". localtime().".\n You can find the working directory here:$project_path\n";
-
-
-
-##Resources
-make_dir($project_path, "Refseqs");
-make_dir($project_path, "EST");
-make_dir($project_path, "RNAseq");
-make_dir($project_path, "Genome");
-make_dir($project_path, "Mito");
-make_dir($project_path, "Delivery");
-make_dir($project_path, "code");
-
-##Ab initio
-make_dir($project_path, "ab-initio");
-make_dir("$project_path/ab-initio", "SNAP");
-make_dir("$project_path/ab-initio", "Augustus");
-make_dir("$project_path/ab-initio", "GeneMark_ET");
-make_dir("$project_path/ab-initio", "GeneMark_EP");
-
-##Maker
-make_dir($project_path, "Maker");
-make_dir("$project_path/Maker", "Evidence_build");
-make_dir("$project_path/Maker", "gene_build");
-
-##Transcriptome assembly
-make_dir($project_path, "RNAseq_alignment");
-make_dir($project_path, "Transcriptome_assembly");
-make_dir("$project_path/Transcriptome_assembly", "Genome_guided");
-make_dir("$project_path/Transcriptome_assembly", "Denovo");
-
-##Prepare fasta file
-prepare_fasta($fasta);
-
-sub prepare_fasta {
-	print "$fasta $project_path/Genome/";
-	system("mv $fasta $project_path/Genome/");
-	system("ln -s $project_path/Genome/$fasta $project_path/Genome/genome.fa");
+## Check if folder exists, otherwise create it and the subfolders
+if ( -e $full_path) {
+    die "$0 WARNING:\nFolder $full_path already exists.\nCowardly refuses to overwrite. Exiting.\n";
+}
+else {
+    for my $folder (@folders) {
+        my $f = $full_path . "/" . $folder;
+        #system("mkdir -p $f");
+        make_path($f)
+    }
 }
 
-sub make_dir {
-#    my $directory = $_[0],"/",$_[1];
-	my ($tmp_path, $tmp_dir) = @_;
-	my $directory = "$tmp_path/$tmp_dir";
-#	print "$directory"; <STDIN>;
-	system("mkdir -p $directory");
-#	mkdir $directory;
-#    unless(mkdir $directory) {
-#	unless(-e $directory or mkdir($directory,775)) {
-#		"Unable to create $directory\n";
-#	}
+## Create README.md
+my $readme_file = $full_path . "/" . "README.md";
+
+open my $FILE, ">", $readme_file or die "$0 ERROR: Could not open file \'$readme_file\' for writing: $!\n";
+
+print $FILE "# README";
+if ($name) {
+    print $FILE " for $name";
 }
+if ($id) {
+    print $FILE ", ID $id";
+}
+print $FILE "\n\n";
+print $FILE "- Created: $time_stamp\n";
+print $FILE "- Last modified: $time_stamp\n";
+print $FILE "- Sign: $logname\n\n";
+print $FILE "## Description:\n\n";
+print $FILE "Text here\n";
+
+close($FILE);
+
+## Last check
+if ( -e $full_path) {
+    print STDERR "Created folders in project $full_path\n";
+}
+else {
+    die "$0 ERROR: No project folder created\n";
+}
+
+
+__END__
+
+=pod
+
+=head1 NAME
+
+gaas_create_annotation_project.pl - Create annotation project file hierarchy
+
+=head1 VERSION
+
+2.0
+
+=head1 SYNOPSIS
+
+gaas_create_annotation_project.pl [options]
+
+ Options:
+   --name               name of project
+   --assembly-version   version string for genome assembly
+   --id                 ID
+   --help               brief help message
+   --version            script version
+   --man                full documentation
+
+
+=head1 OPTIONS
+
+Mandatory arguments to long options are mandatory for short options too.
+
+Note that all arguments are optional.
+
+=over 8
+
+=item B<-n, --name=>I<string>
+
+Name of the project
+
+=item B<-s, --species=>I<string>
+
+Same as B<--name>
+
+=item B<-a, --assembly-version=>I<integer>
+
+Version of the assembly used for the project
+
+=item B<-i, --id=>I<string>
+
+ID (e.g. NBIS redmine ID)
+
+=item B<--help>
+
+Print a brief help message and exits
+
+=item B<--man>
+
+Prints the manual page and exits
+
+=back
+
+=head1 DESCRIPTION
+
+This script will create a project file hierarchy.
+Without any arguments, this is the expected output
+
+    Genus_species-annotation_version-NBIS_ID/
+        |── abinitio/
+        |── customer_data/
+        |── genome/
+        |── maker/
+        |── organelles/
+        |── repeats/
+        |── rfam/
+        |── RNAseq/
+        |── README.md
+
+The name of the parent folder can be changed using the B<--name> or the
+B<--path> options (B<--path> will have precedence over B<--name>).
+
+Default root of the annotation project is I</projects/annotation/>,
+but this can be overridden by providing the full path using B<--path>.
+
+=head1 EXAMPLES
+
+    gaas_create_annotation_project.pl -n Apa_bpa
+    gaas_create_annotation_project.pl -p /full/path/to/Apa_bpa
+    gaas_create_annotation_project.pl -n Apa_bpa -a 1 -i 666
+
+=cut
+

--- a/bin/gaas_create_annotation_project.pl
+++ b/bin/gaas_create_annotation_project.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # file: gaas_create_annotation_project.pl
-# Last modified: ons feb 02, 2022  02:20
+# Last modified: ons feb 02, 2022  02:24
 # Sign: Johan Nylander
 
 use strict;
@@ -11,7 +11,7 @@ use Pod::Usage;
 use File::Path qw(make_path);
 
 ## Globals
-my $annotation_root = "/home/nylander/tmp/gaas"; #"/projects/annotation"
+my $annotation_root = "/projects/annotation";
 my $default_name = "Genus_species-annotation_version-NBIS_ID";
 my $logname = $ENV{LOGNAME};
 my $time_stamp = localtime();

--- a/bin/gaas_create_annotation_project.pl
+++ b/bin/gaas_create_annotation_project.pl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 # file: gaas_create_annotation_project.pl
-# Last modified: tor feb 03, 2022  11:34
+# Last modified: fre feb 11, 2022  03:29
 # Sign: Johan Nylander
 
 use strict;
@@ -23,6 +23,7 @@ my @folders = (
     "maker/maker_evidence",
     "maker/maker_abinitio",
     "organelles",
+    "public_data",
     "repeats",
     "rfam",
     "RNAseq");


### PR DESCRIPTION
This is a new version of the script `gaas_create_annotation_project.pl` as per request from @LucileSol.

Now it basically creates a folder hierarchy, and does not require mandatory arguments (for copying `genome.fas` etc).

**NOTE**: The previous script had an option `-v` which was used for supplying the assembly version. **This is now changed!**

If one want to supply assembly version, the new option is `--assembly-version` (or `-a`).

The option `-v` (or `--version`) is now used for printing the version of the script itself.

This change in options can of course be undone. 